### PR TITLE
Execute emulator tasks in main thread

### DIFF
--- a/umd/apps/runtime/Makefile
+++ b/umd/apps/runtime/Makefile
@@ -52,4 +52,4 @@ include rules.mk
 # the logic to compile and link stuff is in here
 $(TEST_BIN): $(ALLMODULE_OBJS) $(SHARED_LIBS)
 	@echo building $(MODULE)  $@
-	$(TOOLCHAIN_PREFIX)g++ $(ALLMODULE_OBJS) -pthread -L$(ROOT)/external/ -ljpeg -L$(ROOT)/out/core/src/runtime/libnvdla_runtime -lnvdla_runtime -o $@ -Wl,-rpath=.
+	$(TOOLCHAIN_PREFIX)g++ $(ALLMODULE_OBJS) -L$(ROOT)/external/ -ljpeg -L$(ROOT)/out/core/src/runtime/libnvdla_runtime -lnvdla_runtime -o $@ -Wl,-rpath=.

--- a/umd/core/include/nvdla_os_inf.h
+++ b/umd/core/include/nvdla_os_inf.h
@@ -41,17 +41,6 @@
 #define NVDLA_OPEN_APPEND (0x8)
 
 /*
- * Thread structures
- */
-struct NvDlaThreadRec {
-    void *handle;
-};
-typedef struct NvDlaThreadRec NvDlaThread;
-typedef struct NvDlaThreadRec* NvDlaThreadHandle;
-
-typedef void (*NvDlaThreadFunction)(void *args);
-
-/*
  * Files and directory structures.
  */
 typedef enum {
@@ -107,15 +96,6 @@ void NvDlaDebugPrintf( const char *format, ... );
 
 NvU32 NvDlaGetTimeMS(void);
 void NvDlaSleepMS(NvU32 msec);
-
-/*
- * Thread related functions
- */
-NvDlaError
-NvDlaThreadCreate( NvDlaThreadFunction function, void *args,
-    NvDlaThreadHandle *thread);
-void NvDlaThreadJoin(NvDlaThreadHandle thread);
-void NvDlaThreadYield(void);
 
 /*
  * File and directory operations

--- a/umd/core/src/runtime/Runtime.cpp
+++ b/umd/core/src/runtime/Runtime.cpp
@@ -153,31 +153,13 @@ Runtime::~Runtime()
 
 bool Runtime::initEMU(void)
 {
-    bool ok = true;
-
     // Ping EMU device
     if (!m_emu_engine)
     {
         m_emu_engine = new Emulator();
-        m_emu_engine->start();
-
-        // Wait for emulator engine to warm up
-        // We should have the ability to timeout here
-        /*while (!m_emu_engine->ping())
-        {
-            NvDlaSleepMS(200);
-        }*/
-    }
-    else
-    {
-        if (!m_emu_engine->ping())
-        {
-            gLogError << "Emu ping failed (timeout)" << endl;
-            ok = false;
-        }
     }
 
-    return ok;
+    return true;
 }
 
 void Runtime::stopEMU(void)
@@ -185,7 +167,6 @@ void Runtime::stopEMU(void)
     if (m_emu_engine == NULL)
         return;
 
-    m_emu_engine->stop();
     delete m_emu_engine;
     m_emu_engine = NULL;
 }
@@ -695,7 +676,7 @@ NvDlaError Runtime::submitInternal()
 
                     fillEMUTaskAddressList(task, *(emu_task_descs.back()));
 
-                    PROPAGATE_ERROR_FAIL( m_emu_engine->submit(task_mem, 1) );
+                    PROPAGATE_ERROR_FAIL( m_emu_engine->submit(task_mem) );
 
                     emu_instance = (emu_instance + 1) % num_emu_instances;
 

--- a/umd/core/src/runtime/include/priv/Emulator.h
+++ b/umd/core/src/runtime/include/priv/Emulator.h
@@ -48,19 +48,14 @@ public: // externally facing
     Emulator();
     virtual ~Emulator();
 
-    bool ping();
-
-    NvDlaError submit(NvU8* task_mem, bool blocking);
-    NvDlaError start();
-    bool stop();
-    bool run();
+    NvDlaError submit(NvU8* task_mem);
 
 public: // internally facing
+    inline bool debugState() { return false; }
     inline bool debugPrint() { return false; }
     inline bool debugOps() { return false; }
 
 protected:
-    static void threadFunction(void* arg);
     NvDlaError processTask(NvU8* task_mem, std::vector<NvU8*> addressList);
 
     NvS8 getBpe(EMUBufferDescAccessor buffer);
@@ -70,14 +65,6 @@ protected:
                          EMUPowerBufferDescsAccessor bufDescs, std::vector<NvU8*> addressList);
     NvDlaError executeSoftmax(EMUSoftmaxOpDescAccessor opDesc, EMUCommonOpDescAccessor commonOpDesc,
                            EMUSoftmaxBufferDescsAccessor bufDescs, std::vector<NvU8*> addressList);
-
-private:
-    std::queue<NvU8*> m_taskQueue;
-
-    NvDlaThreadHandle m_thread;
-    bool m_threadActive;
-
-    bool m_signalShutdown;
 };
 
 } // nvdla::priv

--- a/umd/port/linux/nvdla_os.c
+++ b/umd/port/linux/nvdla_os.c
@@ -44,45 +44,10 @@
 #include <sys/types.h>
 #include <limits.h>
 #include <errno.h>
-#include <pthread.h>
 
 #include <time.h>
 
 #include "nvdla_os_inf.h"
-
-typedef struct
-{
-    NvDlaThreadFunction function;
-    NvDlaThread        *thread;
-    pthread_mutex_t     barrier;
-    pthread_mutex_t     cond_lock;
-    pthread_cond_t      cond;
-    NvU32               init;
-    void               *thread_args;
-} NvDlaThreadArgs;
-
-static void *thread_wrapper(void *v)
-{
-    NvDlaThreadArgs *args = (NvDlaThreadArgs *)v;
-
-    if (!v)
-        return NULL;
-
-    pthread_mutex_lock(&args->cond_lock);
-    args->init = 1;
-    pthread_cond_signal(&args->cond);
-    pthread_mutex_unlock(&args->cond_lock);
-
-    pthread_mutex_lock(&args->barrier);
-    pthread_mutex_unlock(&args->barrier);
-
-    /* jump to user thread */
-    args->function(args->thread_args);
-    pthread_mutex_destroy(&args->barrier);
-    NvDlaFree(args);
-
-    return NULL;
-}
 
 static NvDlaError getOpenMode(NvU32 flags, int *mode)
 {
@@ -168,96 +133,6 @@ void NvDlaDebugPrintf(const char *format, ... )
     va_start( ap, format );
     vprintf(format, ap);
     va_end( ap );
-}
-
-NvDlaError
-NvDlaThreadCreate( NvDlaThreadFunction function, void *args,
-    NvDlaThreadHandle *thread)
-{
-    NvDlaError e;
-    NvDlaThread *t = NULL;
-    NvDlaThreadArgs *a = NULL;
-    pthread_t *handle = NULL;
-    int err;
-
-    if (!function || !thread)
-        return NvDlaError_BadParameter;
-
-    t = NvDlaAlloc(sizeof(NvDlaThread));
-    if (!t) {
-        e = NvDlaError_InsufficientMemory;
-        goto fail_to_allocate_thread;
-    }
-    NvDlaMemset(t, 0, sizeof(NvDlaThread));
-
-    handle = (pthread_t *)NvDlaAlloc(sizeof(pthread_t));
-    if (!handle) {
-        e = NvDlaError_InsufficientMemory;
-        goto fail_to_allocate_handle;
-    }
-    t->handle = (void *)handle;
-
-    a = NvDlaAlloc(sizeof(NvDlaThreadArgs));
-    if (!a) {
-        e = NvDlaError_InsufficientMemory;
-        goto fail_to_allocate_args;
-    }
-
-    a->function = function;
-    a->thread = t;
-    a->thread_args = args;
-    a->init = 0;
-    (void)pthread_mutex_init(&a->barrier, NULL);
-    (void)pthread_mutex_init(&a->cond_lock, NULL);
-    (void)pthread_cond_init(&a->cond, NULL);
-
-    pthread_mutex_lock(&a->barrier);
-    err = pthread_create((pthread_t *)t->handle, NULL, thread_wrapper, (void *)a);
-    if (err != 0) {
-        e = NvDlaError_InsufficientMemory;
-        goto fail_to_spawn_thread;
-    }
-
-    pthread_mutex_lock(&a->cond_lock);
-    while(!a->init)
-        pthread_cond_wait(&a->cond, &a->cond_lock);
-    *thread = t;
-    pthread_mutex_unlock(&a->cond_lock);
-
-    pthread_mutex_unlock(&a->barrier);
-
-    return NvDlaSuccess;
-
-fail_to_spawn_thread:
-    if(a) {
-        pthread_mutex_unlock(&a->barrier);
-        pthread_mutex_destroy(&a->barrier);
-    }
-    NvDlaFree(a);
-fail_to_allocate_args:
-    NvDlaFree(handle);
-fail_to_allocate_handle:
-    NvDlaFree(t);
-fail_to_allocate_thread:
-    return e;
-}
-
-void NvDlaThreadJoin(NvDlaThreadHandle thread)
-{
-    if (!thread)
-        return;
-
-    int e = pthread_join(*((pthread_t *)thread->handle), 0);
-    if( e != 0 )
-        return;
-
-    NvDlaFree(thread->handle);
-    NvDlaFree(thread);
-}
-
-void NvDlaThreadYield(void)
-{
-    (void)sched_yield();
 }
 
 NvDlaError NvDlaStat(const char *filename, NvDlaStatType *stat)


### PR DESCRIPTION
The threading logic in the emulator was resulting in very long inference
times, due to the long `NvDlaSleepMS` calls when waiting for a new task.
Rather than tuning that sleep loop, this commit just removes all of the
multi-threading logic, since this driver can't overlap multiple
inference tasks or interleave DLA tasks with EMU tasks.

Resolves performance issues mentioned in https://github.com/ucb-bar/chipyard/issues/573