### PR TITLE
Init the NVDLA Spinlock

### DIFF
--- a/kmd/port/linux/nvdla_core_callbacks.c
+++ b/kmd/port/linux/nvdla_core_callbacks.c
@@ -397,6 +397,9 @@ static int32_t nvdla_probe(struct platform_device *pdev)
 	nvdla_dev->pdev = pdev;
 	nvdla_dev->config_data = (struct nvdla_config *)match->data;
 
+	/* init spinlock */
+	spin_lock_init(&nvdla_dev->nvdla_lock);
+
 	init_completion(&nvdla_dev->event_notifier);
 
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);

--- a/kmd/port/linux/nvdla_gem.c
+++ b/kmd/port/linux/nvdla_gem.c
@@ -110,6 +110,9 @@ static int32_t nvdla_submit(struct drm_device *drm, void *arg,
 	task->nvdla_dev = nvdla_dev;
 	task->file = file;
 
+	/* init spinlock */
+	spin_lock_init(&nvdla_dev->nvdla_lock);
+
 	/* update task desc fields */
 	err = nvdla_fill_task_desc(&local_task, task);
 	if (err)

--- a/kmd/port/linux/nvdla_gem.c
+++ b/kmd/port/linux/nvdla_gem.c
@@ -110,9 +110,6 @@ static int32_t nvdla_submit(struct drm_device *drm, void *arg,
 	task->nvdla_dev = nvdla_dev;
 	task->file = file;
 
-	/* init spinlock */
-	spin_lock_init(&nvdla_dev->nvdla_lock);
-
 	/* update task desc fields */
 	err = nvdla_fill_task_desc(&local_task, task);
 	if (err)


### PR DESCRIPTION
This seems to solve the following error brought up in https://github.com/ucb-bar/chipyard/issues/573

```
[    0.586561] BUG: spinlock bad magic on CPU#0, swapper/0/0
[    0.586570]  lock: 0xffffffe3eeee1da8, .magic: 00000000, .owner: <none>/-1, .owner_cpu: 0
[    0.586581] CPU: 0 PID: 0 Comm: swapper/0 Tainted: G           O      5.7.0-rc3-58540-g66e8cf3c569c #9
[    0.586589] Call Trace:
[    0.586659] [<ffffffe00020243a>] walk_stackframe+0x0/0xaa
[    0.586827] [<ffffffe000202626>] show_stack+0x2a/0x34
[    0.586985] [<ffffffe0004864da>] dump_stack+0x6e/0x88
[    0.587142] [<ffffffe000243b40>] spin_dump+0x68/0x74
[    0.587296] [<ffffffe00024374a>] do_raw_spin_lock+0xb0/0xcc
[    0.587471] [<ffffffe000873fa8>] _raw_spin_lock_irqsave+0x20/0x2c
[    0.587789] [<ffffffdf81150294>] nvdla_engine_isr+0x20/0x58 [opendla]
[    0.587862] [<ffffffe0002480a2>] __handle_irq_event_percpu+0x4c/0xe4
[    0.588060] [<ffffffe000248154>] handle_irq_event_percpu+0x1a/0x5c
[    0.588253] [<ffffffe0002481ce>] handle_irq_event+0x38/0x64
[    0.588426] [<ffffffe00024b5ae>] handle_fasteoi_irq+0xae/0x13e
[    0.588608] [<ffffffe0002473ca>] generic_handle_irq+0x28/0x36
[    0.588788] [<ffffffe00049b904>] plic_handle_irq+0x8e/0xd4
[    0.588959] [<ffffffe000874440>] do_IRQ+0x60/0xb8
[    0.589106] [<ffffffe0002011b2>] ret_from_exception+0x0/0xc
```